### PR TITLE
Performance improvements when accessing buckets with many object

### DIFF
--- a/jupyterlab_s3_browser/__init__.py
+++ b/jupyterlab_s3_browser/__init__.py
@@ -212,7 +212,8 @@ def do_list_objects_v2(s3client, bucket_name, prefix):
             for one_object in contents:
                 obj_key = one_object['Key']
                 obj_key_basename = get_basename(prefix, obj_key)
-                list_of_objects.append(Content(obj_key_basename, obj_key, "file", "json"))
+                if len(obj_key_basename) > 0:
+                    list_of_objects.append(Content(obj_key_basename, obj_key, "file", "json"))
         if 'CommonPrefixes' in response:
             common_prefixes = response['CommonPrefixes']
             for common_prefix in common_prefixes:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@jupyterlab/application": "^2.0.0",
     "@jupyterlab/apputils": "^2.0.0",
-    "@jupyterlab/coreutils": "4.0.0",
+    "@jupyterlab/coreutils": "4.0.2",
     "@jupyterlab/docmanager": "^2.0.0",
     "@jupyterlab/docregistry": "^2.0.0",
     "@jupyterlab/filebrowser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@jupyterlab/application": "^2.0.0",
     "@jupyterlab/apputils": "^2.0.0",
-    "@jupyterlab/coreutils": "4.0.2",
+    "@jupyterlab/coreutils": "4.1.0",
     "@jupyterlab/docmanager": "^2.0.0",
     "@jupyterlab/docregistry": "^2.0.0",
     "@jupyterlab/filebrowser": "^2.0.0",

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -212,9 +212,11 @@ export class S3Drive implements Contents.IDrive {
   private _isDisposed = false;
   private _fileChanged = new Signal<this, Contents.IChangedArgs>(this);
 
-  jupyterPathToS3Path(path: string): string {
+  jupyterPathToS3Path(path: string, isDir: boolean): string {
     if (path === "") {
       path = "/";
+    } else if (isDir) {
+      path += "/";
     }
     return path;
   }
@@ -235,7 +237,6 @@ export class S3Drive implements Contents.IDrive {
   }
 
   pathToJupyterContents(path: string): Promise<Contents.IModel> {
-    let s3path = this.jupyterPathToS3Path(path);
     if (
       path !== Private.currentPath && // if we're changing paths...
       Private.availableContentTypes[path] !== "file" // it's not a file
@@ -245,8 +246,12 @@ export class S3Drive implements Contents.IDrive {
       }
       Private.showDirectoryLoadingSpinner();
     }
+    var s3path: string;
     if (Private.availableContentTypes[path] !== "file") {
       Private.currentPath = path;
+      s3path = this.jupyterPathToS3Path(path, true);
+    } else {
+      s3path = this.jupyterPathToS3Path(path, false);
     }
 
     return new Promise((resolve, reject) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ function activateFileBrowser(
 
   const browser = factory.createFileBrowser(NAMESPACE, {
     driveName: drive.name,
+    state: null,
     refreshInterval: 300000
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,7 +151,20 @@
     codemirror "~5.49.2"
     react "~16.9.0"
 
-"@jupyterlab/coreutils@4.0.0", "@jupyterlab/coreutils@^4.0.0":
+"@jupyterlab/coreutils@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-4.0.2.tgz#2ee81799249f5f4741157ac42ff50a2ee48a0475"
+  integrity sha512-v4RXIAeykoPjIymdCxUxPLl8lkn18jroGnDflZjvdMk21TZQQJSIrJ5bjrGByh9scco8yNg46z8m1LPguF3z8A==
+  dependencies:
+    "@lumino/coreutils" "^1.4.2"
+    "@lumino/disposable" "^1.3.5"
+    "@lumino/signaling" "^1.3.5"
+    minimist "~1.2.0"
+    moment "^2.24.0"
+    path-posix "~1.0.0"
+    url-parse "~1.4.7"
+
+"@jupyterlab/coreutils@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-4.0.0.tgz#84ea7cdeedc23989f05d1993ee705d4a0b883f71"
   integrity sha512-f7wvlmJSYiSsjzTjD2wI6iXbt8hPYjWlM0l7J2ULbI7E1tsPmpn14mo/kmF/Ft0cLYXP9ApkItU5QrXB5BNoXA==


### PR DESCRIPTION
This set of changes does the following:

1. Switches to using a lower level boto3 api for accessing s3 buckets: list_objects_v2 and get_object
2. Push the responsibility for adding a / to the end of directory lookups back to the typesecript code that runs in the browser pane
3. Turn off auto restore of last browse location because when jupyterlab calls us back it doesn't tell us whether the path is a directory or a file