### PR TITLE
feature: allow using of STS Session Tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 __pycache__/
 node_modules/
 .vscode/
+.idea/
 npm-debug.log
 yarn-error.log
 package-lock.json

--- a/jupyterlab_s3_browser/__init__.py
+++ b/jupyterlab_s3_browser/__init__.py
@@ -40,6 +40,12 @@ class JupyterLabS3(Configurable):
         help="The client secret for the S3 api",
     )
 
+    session_token = Unicode(
+        default_value=environ.get("JUPYTERLAB_S3_SESSION_TOKEN", ""),
+        config=True,
+        help="(Optional) Token if you use STS as auth method",
+    )
+
 
 def _load_jupyter_server_extension(server_app):
     """Registers the API handler to receive HTTP requests from the frontend extension.

--- a/jupyterlab_s3_browser/handlers.py
+++ b/jupyterlab_s3_browser/handlers.py
@@ -154,6 +154,7 @@ class AuthHandler(APIHandler):  # pylint: disable=abstract-method
             self.config.endpoint_url = endpoint_url
             self.config.client_id = client_id
             self.config.client_secret = client_secret
+            self.config.session_token = session_token
 
             self.finish(json.dumps({"success": True}))
         except Exception as err:

--- a/jupyterlab_s3_browser/handlers.py
+++ b/jupyterlab_s3_browser/handlers.py
@@ -16,7 +16,7 @@ from jupyter_server.utils import url_path_join
 
 def create_s3_resource(config):
 
-    if config.endpoint_url and config.client_id and config.client_secret and config.session_token:
+    if config.endpoint_url and config.client_id and config.client_secret:
 
         return boto3.resource(
             "s3",
@@ -114,9 +114,12 @@ class AuthHandler(APIHandler):  # pylint: disable=abstract-method
 
             try:
                 config = self.config
-                if config.endpoint_url and config.client_id and config.client_secret and config.session_token:
+                if config.endpoint_url and config.client_id and config.client_secret:
                     test_s3_credentials(
-                        config.endpoint_url, config.client_id, config.client_secret, config.session_token
+                        config.endpoint_url,
+                        config.client_id,
+                        config.client_secret,
+                        config.session_token,
                     )
                     logging.debug("...successfully authenticated")
 

--- a/jupyterlab_s3_browser/handlers.py
+++ b/jupyterlab_s3_browser/handlers.py
@@ -16,13 +16,14 @@ from jupyter_server.utils import url_path_join
 
 def create_s3_resource(config):
 
-    if config.endpoint_url and config.client_id and config.client_secret:
+    if config.endpoint_url and config.client_id and config.client_secret and config.session_token:
 
         return boto3.resource(
             "s3",
             aws_access_key_id=config.client_id,
             aws_secret_access_key=config.client_secret,
             endpoint_url=config.endpoint_url,
+            aws_session_token=config.session_token,
         )
     else:
         return boto3.resource("s3")
@@ -68,7 +69,7 @@ def has_aws_s3_role_access():
         return False
 
 
-def test_s3_credentials(endpoint_url, client_id, client_secret):
+def test_s3_credentials(endpoint_url, client_id, client_secret, session_token):
     """
     Checks if we're able to list buckets with these credentials.
     If not, it throws an exception.
@@ -79,6 +80,7 @@ def test_s3_credentials(endpoint_url, client_id, client_secret):
         aws_access_key_id=client_id,
         aws_secret_access_key=client_secret,
         endpoint_url=endpoint_url,
+        aws_session_token=session_token,
     )
     all_buckets = test.buckets.all()
     logging.debug(
@@ -112,9 +114,9 @@ class AuthHandler(APIHandler):  # pylint: disable=abstract-method
 
             try:
                 config = self.config
-                if config.endpoint_url and config.client_id and config.client_secret:
+                if config.endpoint_url and config.client_id and config.client_secret and config.session_token:
                     test_s3_credentials(
-                        config.endpoint_url, config.client_id, config.client_secret
+                        config.endpoint_url, config.client_id, config.client_secret, config.session_token
                     )
                     logging.debug("...successfully authenticated")
 
@@ -142,8 +144,9 @@ class AuthHandler(APIHandler):  # pylint: disable=abstract-method
             endpoint_url = req["endpoint_url"]
             client_id = req["client_id"]
             client_secret = req["client_secret"]
+            session_token = req["session_token"]
 
-            test_s3_credentials(endpoint_url, client_id, client_secret)
+            test_s3_credentials(endpoint_url, client_id, client_secret, session_token)
 
             self.config.endpoint_url = endpoint_url
             self.config.client_id = client_id

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-s3-browser",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "JupyterLab extension for browsing S3-compatible object storage",
   "keywords": [
     "s3",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -127,6 +127,12 @@ namespace Private {
             h.label({}, 'Secret Access Key'),
             h.br(),
             h.input({ type: 'password', name: 'client_secret' })
+          ),
+          h.br(),
+          h.p(
+            h.label({}, '(Optional) Session Token'),
+            h.br(),
+            h.input({ type: 'password', name: 'session_token' })
           )
         ),
         h.br(),


### PR DESCRIPTION
Hello,

Thank you for such a good extension! We'd like to use it in environment where we create temporary users in [Minio using STS ](https://docs.min.io/docs/minio-sts-quickstart-guide.html) (which pretends to copy AWS STS behaviour). Hence we really need to also specify Session Token's.  

I've tested boto3 behaviour with both `boto3.resource(..., session_token=None)` and `boto3.resource(..., session_token='')` towards AWS S3 and it still works as expected so that would be nice to have:  

![image](https://user-images.githubusercontent.com/1599647/112984563-b5a3c500-9167-11eb-9886-22bfb7749bab.png)
