### PR TITLE
correct sidebar-icon position

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ function activateFileBrowser(
 
   // Add the file browser widget to the application restorer.
   restorer.add(s3Browser, NAMESPACE);
-  app.shell.add(s3Browser, 'left', { rank: 100 });
+  app.shell.add(s3Browser, 'left', { rank: 501 });
 
   return;
 }


### PR DESCRIPTION
Following the recommendations for `rank` from the documentation here
https://jupyterlab.readthedocs.io/en/stable/extension/extension_points.html#left-right-areas
```
0-500: reserved for first-party JupyterLab extensions.
501-899: reserved for third-party extensions.
900: The default rank if none is specified.
1000: The JupyterLab extension manager.
```
`rank` will be set to 501 by this PR
Issue: https://github.com/IBM/jupyterlab-s3-browser/issues/74
