### PR TITLE
Allow transparent usage of s3 interfaces using s3v2 signature_version

### DIFF
--- a/docs/SAGEMAKER.md
+++ b/docs/SAGEMAKER.md
@@ -1,14 +1,42 @@
 # Running on AWS SageMaker
 
-If you're using AWS SageMaker,
+If you're using AWS SageMaker, make sure what version of JupyterLab it is
+running. If you are not sure, you can open a terminal and running the following
+command:
+
+```
+jupyter --version
+```
+
+Look for the line with the name "jupyterlab".
+
+**If the version is JupyterLab 1.x or 2.x:**
 
 1. Stop and start your sagemaker instance (to make sure you're starting fresh)
-2. Open a terminal, and run `source activate JupyterSystemEnv` to switch to JupyterLab's conda environment
+2. Open a terminal, and run `source activate JupyterSystemEnv` to switch to JupyterLab's conda environm
+ent
 3. Run `jupyter labextension install jupyterlab-s3-browser` to install the lab extension
 4. Run `pip install jupyterlab-s3-browser` to install the server extension
-5. Run `jupyter serverextension enable --py jupyterlab_s3_browser` to make sure the server extension is enabled
+5. Run `jupyter serverextension enable --py jupyterlab_s3_browser` to make sure the server extension is
+ enabled
 6. Run `sudo initctl restart jupyter-server --no-wait` to restart your jupyterlab server
 7. Refresh the page
-8. You should now have the bucket icon on your sidebar. Use https://s3.amazonaws.com as your endpoint. Enter your access key and secret key generated on this page: https://console.aws.amazon.com/iam/home#security_credential
 
-You'll need to perform these instructions every time you log in, because SageMaker doesn't save the state of your installed extensions.
+**If the version is JupyterLab 3.x:**
+
+1. Stop and start your sagemaker instance (to make sure you're starting fresh)
+2. Open a terminal, and run `conda activate studio` to switch to JupyterLab's conda environment
+3. Run `pip install jupyterlab-s3-browser` to install the server extension
+4. Run `jupyter serverextension enable --py jupyterlab_s3_browser` to make sure the server extension is
+ enabled
+5. Run `restart-jupyter-server` to restart your jupyterlab server
+6. Refresh the page
+
+You should now have the bucket icon on your sidebar. Use
+https://s3.amazonaws.com as your endpoint. Enter your access key and secret key
+generated on this page:
+https://console.aws.amazon.com/iam/home#security_credential.
+
+You'll need to perform these instructions every time you log in, because SageMaker doesn't save the sta
+te of your installed extensions. However, you can create a lifecycle configuration that executes those 
+commands (except restarting the server) every time an instance is created

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/IBM/jupyterlab_s3_browser.git"
+    "url": "https://github.com/IBM/jupyterlab-s3-browser.git"
   },
   "scripts": {
     "build": "jlpm run build:lib && jlpm run build:labextension:dev",

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ function activateFileBrowser(
 
   // Add the file browser widget to the application restorer.
   restorer.add(s3Browser, NAMESPACE);
-  app.shell.add(s3Browser, 'left', { rank: 100 });
+  app.shell.add(s3Browser, 'left', { rank: 501 });
 
   return;
 }


### PR DESCRIPTION
Added a config variable "signature_version" that is set through trying an s3v4 signature first, then falls back to s3v2 through excepting on a ClientError if s3v4 isn't accepted by the s3 interface.

This is required for transparently allowing users to connect to S3 interfaces that cannot be updated to use the s3v4 signature_version.